### PR TITLE
PNDA-4427: Add Flink software to PNDA build and mirror processes

### DIFF
--- a/pillar/services.sls
+++ b/pillar/services.sls
@@ -57,6 +57,9 @@ jupyterproxy:
 gobblin:
   release_version: 0.11.0
 
+flink:
+  release_version: 1.4.0
+
 platform_gobblin_modules:
   release_version: develop
 


### PR DESCRIPTION
# Problem Statement:
PNDA-4427: Add Flink software to PNDA build and mirror processes

# Analysis:
Flink build version not available in the list of supported services.

# Change:
Added the Flink ( version = 1.4.0 ) to the list of supported services.

# Test details:
Verified the fix for AWS:
UBUNTU - PICO -CDH & HDP
UBUNTU - STD -CDH & HDP
RHEL - PICO -CDH & HDP
RHEL - STD -CDH & HDP
Verification Done for openstack.
