### PR TITLE
PNDA-4431: Add basic platform test & console elements for Flink

### DIFF
--- a/pillar/services.sls
+++ b/pillar/services.sls
@@ -61,6 +61,9 @@ jupyterproxy:
 gobblin:
   release_version: 0.11.0
 
+flink:
+  release_version: 1.4.0
+
 platform_gobblin_modules:
   release_version: develop
 

--- a/salt/console-frontend/init.sls
+++ b/salt/console-frontend/init.sls
@@ -41,6 +41,7 @@
 {% set grafana_link = salt['pnda.generate_http_link']('grafana',':3000') %}
 {% set kibana_link = salt['pnda.generate_http_link']('logserver',':5601') %}
 {% set jupyter_link = salt['pnda.generate_external_link']('jupyter',':8000') %}
+{% set flink_link = salt['pnda.generate_external_link']('flink',':8082') %}
 {% set login_mode = 'PAM' %}
 
 include:
@@ -107,6 +108,7 @@ console-frontend-create_pnda_console_config:
         grafana_link: "{{ grafana_link }}"
         kibana_link: "{{ kibana_link }}"
         jupyter_link: "{{ jupyter_link }}"
+        flink_link: "{{ flink_link }}"
         login_mode: "{{ login_mode }}"
 
 # Create a configuration file for nginx and specify where the PNDA console file are

--- a/salt/console-frontend/templates/PNDA.json.tpl
+++ b/salt/console-frontend/templates/PNDA.json.tpl
@@ -26,6 +26,10 @@
     {
       "name": "Jupyter",
       "link": "{{ jupyter_link }}"
+    },
+    {
+      "name": "Flink",
+      "link": "{{ flink_link }}"
     }
   ],
   "frontend": {

--- a/salt/flink/init.sls
+++ b/salt/flink/init.sls
@@ -1,0 +1,95 @@
+{% set flavor_cfg = pillar['pnda_flavor']['states'][sls] %}
+
+{% set packages_server = pillar['packages_server']['base_uri'] %}
+{% set flink_version = pillar['flink']['release_version'] %}
+
+{% if grains['hadoop.distro'] == 'HDP' %}
+{% set flink_package = 'flink-' + flink_version + '-HDP.tar.gz' %}
+{% else %}
+{% set flink_package = 'flink-' + flink_version + '-CDH.tar.gz' %}
+{% endif %}
+
+{% set pnda_home = pillar['pnda']['homedir'] %}
+{% set pnda_user  = pillar['pnda']['user'] %}
+{% set flink_real_dir = pnda_home + '/flink-' + flink_version %}
+{% set flink_link_dir = pnda_home + '/flink' %}
+
+{% set namenode = salt['pnda.hadoop_namenode']() %}
+{% set archive_dir = pnda_user + '/flink/completed-jobs' %}
+{% set archive_dir_hdfs_path = namenode + '/' + archive_dir %}
+
+{% if grains['hadoop.distro'] == 'HDP' %}
+{% set hadoop_home_bin = '/usr/hdp/current/hadoop-client/bin/' %}
+{% else %}
+{% set hadoop_home_bin = '/opt/cloudera/parcels/CDH/bin' %}
+{% endif %}
+
+flink-create_flink_version_directory:
+  file.directory:
+    - name: {{ flink_real_dir }}
+    - makedirs: True
+
+flink-dl-and-extract:
+  archive.extracted:
+    - name: {{ flink_real_dir }}
+    - source: {{ packages_server }}/{{ flink_package }}
+    - source_hash: {{ packages_server }}/{{ flink_package }}.sha512.txt
+    - archive_format: tar
+    - tar_options: ''
+    - if_missing: {{ flink_real_dir }}/bin
+    - require:
+      - file: flink-create_flink_version_directory
+
+flink-copy_configurations:
+  file.managed:
+    - name: {{ flink_real_dir }}/conf/flink-conf.yaml
+    - source: salt://flink/templates/flink.conf.tpl
+    - template: jinja
+    - context:
+      jmnode: 'localhost'
+      namenode: {{ namenode }}
+      path: {{ archive_dir }}
+
+flink-configure_log_dir:
+  file.directory:
+    - name: {{ flink_real_dir }}/log
+    - makedirs: True
+    - user: pnda
+    - group: pnda
+    - mode: 0744
+
+flink-create_link:
+  file.symlink:
+    - name: {{ flink_link_dir }}
+    - target: {{ flink_real_dir }}
+    - require:
+      - archive: flink-dl-and-extract
+
+flink-create_flink_logs_directory:
+  file.directory:
+    - name: /var/log/pnda/flink
+    - user: {{ pnda_user }}
+    - makedirs: True
+
+flink-jobmanager_archive_dir_initialize-hdfs:
+  cmd.run:
+    - name: 'sudo -u hdfs hdfs dfs -mkdir -p {{ archive_dir_hdfs_path }}; sudo -u hdfs hdfs dfs -chmod 777 {{ archive_dir_hdfs_path }}'
+
+flink-copy_service:
+  file.managed:
+{% if grains['os'] == 'Ubuntu' %}
+    - name: /etc/init/flink-history-server.conf
+    - source: salt://flink/templates/flink-service.conf.tpl
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
+    - name: /usr/lib/systemd/system/flink-history-server.service
+    - source: salt://flink/templates/flink-service.service.tpl
+{% endif %}
+    - template: jinja
+    - defaults:
+        install_dir: {{ flink_link_dir }}
+
+flink-history_server_start_service:
+  service.running:
+    - name: flink-history-server
+    - enable: True
+    - reload: True

--- a/salt/flink/templates/flink-service.conf.tpl
+++ b/salt/flink/templates/flink-service.conf.tpl
@@ -1,0 +1,18 @@
+# Upstart file at /etc/init/flink-history-service.conf
+description "Flink-History-Server Service"
+
+start on runlevel [2345]
+stop on runlevel [016]
+
+normal exit 0
+respawn
+respawn limit unlimited
+post-stop exec sleep 2
+
+setuid pnda
+setgid pnda
+
+chdir {{ install_dir }}
+pre-start exec bin/historyserver.sh start
+post-stop exec bin/historyserver.sh stop
+

--- a/salt/flink/templates/flink-service.service.tpl
+++ b/salt/flink/templates/flink-service.service.tpl
@@ -1,0 +1,15 @@
+[Unit]
+Description=Flink-History-Server Service
+
+[Service]
+Type=forking
+User=pnda
+Group=pnda
+WorkingDirectory={{ install_dir }}
+ExecStart={{ install_dir }}/bin/historyserver.sh start
+ExecStop={{ install_dir }}/bin/historyserver.sh stop
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/flink/templates/flink.conf.tpl
+++ b/salt/flink/templates/flink.conf.tpl
@@ -1,0 +1,230 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+
+#==============================================================================
+# Common
+#==============================================================================
+
+# The external address of the host on which the JobManager runs and can be
+# reached by the TaskManagers and any clients which want to connect. This setting
+# is only used in Standalone mode and may be overwritten on the JobManager side
+# by specifying the --host <hostname> parameter of the bin/jobmanager.sh executable.
+# In high availability mode, if you use the bin/start-cluster.sh script and setup
+# the conf/masters file, this will be taken care of automatically. Yarn/Mesos
+# automatically configure the host name based on the hostname of the node where the
+# JobManager runs.
+
+jobmanager.rpc.address: {{ jmnode }}
+
+# The RPC port where the JobManager is reachable.
+
+jobmanager.rpc.port: 6123
+
+
+# The heap size for the JobManager JVM
+
+jobmanager.heap.mb: 1024
+
+
+# The heap size for the TaskManager JVM
+
+taskmanager.heap.mb: 1024
+
+
+# The number of task slots that each TaskManager offers. Each slot runs one parallel pipeline.
+
+taskmanager.numberOfTaskSlots: 1
+
+# Specify whether TaskManager memory should be allocated when starting up (true) or when
+# memory is required in the memory manager (false)
+# Important Note: For pure streaming setups, we highly recommend to set this value to `false`
+# as the default state backends currently do not use the managed memory.
+
+taskmanager.memory.preallocate: false
+
+# The parallelism used for programs that did not specify and other parallelism.
+
+parallelism.default: 1
+
+
+#==============================================================================
+# Web Frontend
+#==============================================================================
+
+# The address under which the web-based runtime monitor listens.
+#
+#jobmanager.web.address: 0.0.0.0
+
+# The port under which the web-based runtime monitor listens.
+# A value of -1 deactivates the web server.
+
+web.port: 8081
+
+# Flag to specify whether job submission is enabled from the web-based
+# runtime monitor. Uncomment to disable.
+
+#jobmanager.web.submit.enable: false
+
+#==============================================================================
+# HistoryServer
+#==============================================================================
+
+# The HistoryServer is started and stopped via bin/historyserver.sh (start|stop)
+
+# Directory to upload completed jobs to. Add this directory to the list of
+# monitored directories of the HistoryServer as well (see below).
+jobmanager.archive.fs.dir: {{ namenode }}/{{ path }}
+
+# The address under which the web-based HistoryServer listens.
+historyserver.web.address: 0.0.0.0
+
+# The port under which the web-based HistoryServer listens.
+historyserver.web.port: 8082
+
+# Comma separated list of directories to monitor for completed jobs.
+# Currently configured the history-server archive directory to read it from job-manager archive directory.
+historyserver.archive.fs.dir: {{ namenode }}/{{ path }}
+
+# Interval in milliseconds for refreshing the monitored directories.
+historyserver.archive.fs.refresh-interval: 10000
+
+#==============================================================================
+# Streaming state checkpointing
+#==============================================================================
+
+# The backend that will be used to store operator state checkpoints if
+# checkpointing is enabled.
+#
+# Supported backends: jobmanager, filesystem, rocksdb, <class-name-of-factory>
+#
+# state.backend: filesystem
+
+
+# Directory for storing checkpoints in a Flink-supported filesystem
+# Note: State backend must be accessible from the JobManager and all TaskManagers.
+# Use "hdfs://" for HDFS setups, "file://" for UNIX/POSIX-compliant file systems,
+# (or any local file system under Windows), or "s3://" with lower case 's' for S3 file system.
+#
+# state.backend.fs.checkpointdir: hdfs://namenode-host:port/flink-checkpoints
+
+
+#==============================================================================
+# Advanced
+#==============================================================================
+
+# The number of buffers for the network stack.
+#
+# taskmanager.network.numberOfBuffers: 2048
+
+
+# Directories for temporary files.
+#
+# Add a delimited list for multiple directories, using the system directory
+# delimiter (colon ':' on unix) or a comma, e.g.:
+#     /data1/tmp:/data2/tmp:/data3/tmp
+#
+# Note: Each directory entry is read from and written to by a different I/O
+# thread. You can include the same directory multiple times in order to create
+# multiple I/O threads against that directory. This is for example relevant for
+# high-throughput RAIDs.
+#
+# If not specified, the system-specific Java temporary directory (java.io.tmpdir
+# property) is taken.
+#
+# taskmanager.tmp.dirs: /tmp
+
+
+# Path to the Hadoop configuration directory.
+#
+# This configuration is used when writing into HDFS. Unless specified otherwise,
+# HDFS file creation will use HDFS default settings with respect to block-size,
+# replication factor, etc.
+#
+# You can also directly specify the paths to hdfs-default.xml and hdfs-site.xml
+# via keys 'fs.hdfs.hdfsdefault' and 'fs.hdfs.hdfssite'.
+#
+# fs.hdfs.hadoopconf: /path/to/hadoop/conf/
+
+
+#==============================================================================
+# High Availability
+#==============================================================================
+
+# The high-availability mode. Possible options are 'NONE' or 'zookeeper'.
+#
+# high-availability: zookeeper
+
+# The path where metadata for master recovery is persisted. While ZooKeeper stored
+# the small ground truth for checkpoint and leader election, this location stores
+# the larger objects, like persisted dataflow graphs.
+#
+# Must be a durable file system that is accessible from all nodes
+# (like HDFS, S3, Ceph, nfs, ...)
+#
+# high-availability.storageDir: hdfs:///flink/ha/
+
+# The list of ZooKeeper quorum peers that coordinate the high-availability
+# setup. This must be a list of the form:
+# "host1:clientPort,host2:clientPort,..." (default clientPort: 2181)
+#
+# high-availability.zookeeper.quorum: localhost:2181
+
+
+# ACL options are based on https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_BuiltinACLSchemes
+# It can be either "creator" (ZOO_CREATE_ALL_ACL) or "open" (ZOO_OPEN_ACL_UNSAFE)
+# The default value is "open" and it can be changed to "creator" if ZK security is enabled
+#
+# high-availability.zookeeper.client.acl: open
+
+#==============================================================================
+# Flink Cluster Security Configuration (optional configuration)
+#==============================================================================
+
+# Kerberos authentication for various components - Hadoop, ZooKeeper, and connectors -
+# may be enabled in four steps:
+# 1. configure the local krb5.conf file
+# 2. provide Kerberos credentials (either a keytab or a ticket cache w/ kinit)
+# 3. make the credentials available to various JAAS login contexts
+# 4. configure the connector to use JAAS/SASL
+
+# The below configure how Kerberos credentials are provided. A keytab will be used instead of
+# a ticket cache if the keytab path and principal are set.
+
+# security.kerberos.login.use-ticket-cache: true
+# security.kerberos.login.keytab: /path/to/kerberos/keytab
+# security.kerberos.login.principal: flink-user
+
+# The configuration below defines which JAAS login contexts
+
+# security.kerberos.login.contexts: Client,KafkaClient
+
+#==============================================================================
+# ZK Security Configuration (optional configuration)
+#==============================================================================
+
+# Below configurations are applicable if ZK ensemble is configured for security
+
+# Override below configuration to provide custom ZK service name if configured
+# zookeeper.sasl.service-name: zookeeper
+
+# The configuration below must match one of the values set in "security.kerberos.login.contexts"
+# zookeeper.sasl.login-context-name: Client
+
+# Configure log directory path for PNDA flink
+env.log.dir: /var/log/pnda/flink

--- a/salt/orchestrate/pnda.sls
+++ b/salt/orchestrate/pnda.sls
@@ -116,6 +116,14 @@ orchestrate-pnda-install_spark_wrapper:
     - timeout: 120
     - queue: True
 
+orchestrate-pnda-install_flink:
+  salt.state:
+    - tgt: 'G@pnda_cluster:{{pnda_cluster}} and G@roles:flink'
+    - tgt_type: compound
+    - sls: flink
+    - timeout: 120
+    - queue: True
+
 orchestrate-pnda-install_gobblin:
   salt.state:
     - tgt: 'G@pnda_cluster:{{pnda_cluster}} and G@roles:gobblin'

--- a/salt/platform-testing/general.sls
+++ b/salt/platform-testing/general.sls
@@ -12,6 +12,7 @@
 {% set zookeeper_port = '2181' %}
 {% set dm_port = '5000' %}
 {% set opentsdb_port = '4242' %}
+{% set flink_history_server_port = '8082' %}
 
 {% set pnda_cluster = salt['pnda.cluster_name']() %}
 
@@ -40,6 +41,14 @@
 {%- if dm_nodes is not none and dm_nodes|length > 0 -%}
   {%- for ip in dm_nodes -%}
   {%- do dm_hosts.append("http://" + ip + ':' + dm_port) -%}
+  {%- endfor -%}
+{%- endif -%}
+
+{%- set fh_hosts = [] -%}
+{%- set fh_nodes = salt['pnda.ip_addresses']('flink') -%}
+{%- if fh_nodes is not none and fh_nodes|length > 0 -%}
+  {%- for ip in fh_nodes -%}
+    {%- do fh_hosts.append("http://" + ip + ':' + flink_history_server_port) -%}
   {%- endfor -%}
 {%- endif -%}
 
@@ -233,6 +242,44 @@ platform-testing-general-crontab-dm-blackbox:
     - name: /sbin/start platform-testing-general-dm-blackbox
 {% elif grains['os'] in ('RedHat', 'CentOS') %}
     - name: /bin/systemctl start platform-testing-general-dm-blackbox
+{% endif %}
+
+{% endif %}
+
+{%- if fh_hosts is not none and fh_hosts|length > 0 %}
+platform-testing-general-install-requirements-flink:
+  pip.installed:
+    - bin_env: {{ virtual_env_dir }}
+    - requirements: {{ platform_testing_directory }}/{{platform_testing_package}}-{{ platform_testing_version }}/plugins/flink/requirements.txt
+    - index_url: {{ pip_index_url }}
+    - require:
+      - virtualenv: platform-testing-general-create-venv
+
+platform-testing-general-flink_service:
+  file.managed:
+{% if grains['os'] == 'Ubuntu' %}
+    - source: salt://platform-testing/templates/platform-testing-general-flink.conf.tpl
+    - name: /etc/init/platform-testing-general-flink.conf
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
+    - source: salt://platform-testing/templates/platform-testing-general-flink.service.tpl
+    - name: /usr/lib/systemd/system/platform-testing-general-flink.service
+{%- endif %}
+    - mode: 644
+    - template: jinja
+    - context:
+      platform_testing_directory: {{ platform_testing_directory }}
+      platform_testing_package: {{ platform_testing_package }}
+      console_hosts: {{ console_hosts }}
+      fh_hosts: {{ fh_hosts }}
+
+platform-testing-general-crontab-flink:
+  cron.present:
+    - identifier: PLATFORM-TESTING-FLINK
+    - user: root
+{% if grains['os'] == 'Ubuntu' %}
+    - name: /sbin/start platform-testing-general-flink
+{% elif grains['os'] in ('RedHat', 'CentOS') %}
+    - name: /bin/systemctl start platform-testing-general-flink
 {% endif %}
 
 {% endif %}

--- a/salt/platform-testing/templates/platform-testing-general-flink.conf.tpl
+++ b/salt/platform-testing/templates/platform-testing-general-flink.conf.tpl
@@ -1,0 +1,6 @@
+description "Platform testing general flink upstart script"
+author      "PNDA team"
+start on runlevel [2345]
+task
+env PYTHON_HOME={{ platform_testing_directory }}/{{platform_testing_package}}/venv
+exec ${PYTHON_HOME}/bin/python {{ platform_testing_directory }}/{{platform_testing_package}}/monitor.py --plugin flink --postjson http://{{ console_hosts|join(',') }}/metrics --extra "--fhendpoint {{ fh_hosts|join(',') }}"

--- a/salt/platform-testing/templates/platform-testing-general-flink.service.tpl
+++ b/salt/platform-testing/templates/platform-testing-general-flink.service.tpl
@@ -1,0 +1,6 @@
+[Unit]
+Description=Platform testing general Flink
+
+[Service]
+Type=oneshot
+ExecStart={{ platform_testing_directory }}/{{platform_testing_package}}/venv/bin/python {{ platform_testing_directory }}/{{platform_testing_package}}/monitor.py --plugin flink --postjson http://{{ console_hosts|join(',') }}/metrics --extra "--fhendpoint {{ fh_hosts|join(',') }}"


### PR DESCRIPTION
# Problem Statement:
PNDA-4431: Add basic platform test & console elements for flink

Dependency PR:
- https://github.com/GaneshManal/platform-testing/pull/1
- https://github.com/GaneshManal/platform-console-frontend/pull/1

# Analysis:
The platform testing framework i.e. periodic service for flink platform test is not configured.
from pnda component in console, button should redirect to flink-history-server web UI.

# Change:
Added flink platform testing general service.
Configured backend to setup up appropriate link for pnda console element.

# Test details:
Verified the fix for AWS:
UBUNTU - PICO -CDH & HDP
UBUNTU - STD -CDH & HDP
RHEL - PICO -CDH & HDP
RHEL - STD -CDH & HDP
Verification Done for openstack.
